### PR TITLE
Update README info about dependency from 'six'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The latest stable version of library is available on PyPI:
 
     pip install robotframework-reportportal
 
-[reportportal-client](https://github.com/reportportal/client-Python) will be installed as a dependency
+[reportportal-client](https://github.com/reportportal/client-Python) and [six](https://pypi.org/project/six/) will be installed as dependencies
 
 ## Usage
 


### PR DESCRIPTION
requested by [#14](https://github.com/reportportal/agent-Python-RobotFramework/issues/14)
'six' library exists in requirements list. PR updates info about dependencies in README.
I propose to use some tool like this https://requires.io for dependency monitoring in future.
