### PR TITLE
Fixes for using python 3.6

### DIFF
--- a/robotframework_reportportal/model.py
+++ b/robotframework_reportportal/model.py
@@ -78,7 +78,7 @@ class Keyword(object):
 
 class LogMessage(text_type):
     def __init__(self, *args, **kwargs):
-        super(LogMessage, self).__init__(*args, **kwargs)
+        super(LogMessage, self).__init__()
         self.message = self
         self.level = "INFO"
         self.attachment = None

--- a/robotframework_reportportal/variables.py
+++ b/robotframework_reportportal/variables.py
@@ -40,4 +40,4 @@ class Variables(object):
                 "You should pass -v RP_PROJECT:<project_name_value>")
         Variables.launch_doc = get_variable("RP_LAUNCH_DOC", default=None)
         Variables.launch_tags = get_variable("RP_LAUNCH_TAGS", default="").split(" ")
-        Variables.log_batch_size = get_variable("RP_LOG_BATCH_SIZE", default="20")
+        Variables.log_batch_size = int(get_variable("RP_LOG_BATCH_SIZE", default="20"))


### PR DESCRIPTION
Fixes these errors:
model.py::
`[ ERROR ] Calling method 'log_message' of listener 'robotframework_reportportal.listener' failed: TypeError: object.__init__() takes no parameters`

variables.py::
```
Traceback (most recent call last):
  File ".../lib/python3.6/site-packages/reportportal_client/service_async.py", line 231, in process_item
    self.process_log(**kwargs)
  File ".../lib/python3.6/site-packages/reportportal_client/service_async.py", line 214, in process_log
    if len(self.log_batch) >= self.log_batch_size:
TypeError: '>=' not supported between instances of 'int' and 'str'
```

Internal testing of 'Robot Framework 3.1.2 (Python 2.7.5 on linux2)' and 'Robot Framework 3.1.2 (Python 3.6.6 on linux)' both worked uploading proper launch data to reportportal server.
Both running in their own virtual env with:
reportportal-client==3.2.3
robotframework-seleniumlibrary==4.0.0
robotframework-sshlibrary==3.4.0
selenium==3.141.0