### PR TITLE
Robotframework v4.0 support

### DIFF
--- a/robotframework_reportportal/result_visitor.py
+++ b/robotframework_reportportal/result_visitor.py
@@ -27,7 +27,10 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            'totaltests': suite.statistics.all.total,
+            try:
+                'totaltests': suite.statistics.all.total,
+            except:
+                'totaltests': suite.statistics.total,
             'starttime': suite.starttime
         }
         listener.start_suite(suite.name, attrs)
@@ -41,7 +44,10 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            'totaltests': suite.statistics.all.total,
+            try:
+                'totaltests': suite.statistics.all.total,
+            except:
+                'totaltests': suite.statistics.total,
             'starttime': suite.starttime,
             'endtime': suite.endtime,
             'elapsedtime': suite.elapsedtime,
@@ -58,7 +64,10 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            'critical': test.critical,
+            try:
+                'critical': test.critical,
+            except:
+                'critical': '',
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,
@@ -72,7 +81,10 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            'critical': test.critical,
+            try:
+                'critical': test.critical,
+            except:
+                'critical': '',
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,

--- a/robotframework_reportportal/result_visitor.py
+++ b/robotframework_reportportal/result_visitor.py
@@ -27,7 +27,7 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            'totaltests': suite.statistics.all.total if hasattr(suite.statistics.all.total, 'total') else suite.statistics.total,
+            'totaltests': suite.statistics.all.total if hasattr(suite.statistics, 'all') else suite.statistics.total,
             'starttime': suite.starttime
         }
         listener.start_suite(suite.name, attrs)
@@ -41,7 +41,7 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            'totaltests': suite.statistics.all.total if hasattr(suite.statistics.all.total, 'total') else suite.statistics.total,
+            'totaltests': suite.statistics.all.total if hasattr(suite.statistics, 'all') else suite.statistics.total,
             'starttime': suite.starttime,
             'endtime': suite.endtime,
             'elapsedtime': suite.elapsedtime,
@@ -58,7 +58,7 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            'critical': test.critical if hasattr (test.critical, 'critical') else '',
+            'critical': test.critical if hasattr(test, 'critical') else '',
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,
@@ -72,7 +72,7 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            'critical': test.critical if hasattr (test.critical, 'critical') else '',
+            'critical': test.critical if hasattr(test, 'critical') else '',
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,

--- a/robotframework_reportportal/result_visitor.py
+++ b/robotframework_reportportal/result_visitor.py
@@ -27,10 +27,7 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            try:
-                'totaltests': suite.statistics.all.total,
-            except:
-                'totaltests': suite.statistics.total,
+            'totaltests': suite.statistics.all.total if hasattr(suite.statistics.all.total, 'total') else suite.statistics.total,
             'starttime': suite.starttime
         }
         listener.start_suite(suite.name, attrs)
@@ -44,10 +41,7 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            try:
-                'totaltests': suite.statistics.all.total,
-            except:
-                'totaltests': suite.statistics.total,
+            'totaltests': suite.statistics.all.total if hasattr(suite.statistics.all.total, 'total') else suite.statistics.total,
             'starttime': suite.starttime,
             'endtime': suite.endtime,
             'elapsedtime': suite.elapsedtime,
@@ -64,10 +58,7 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            try:
-                'critical': test.critical,
-            except:
-                'critical': '',
+            'critical': test.critical if hasattr (test.critical, 'critical') else '',
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,
@@ -81,10 +72,7 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            try:
-                'critical': test.critical,
-            except:
-                'critical': '',
+            'critical': test.critical if hasattr (test.critical, 'critical') else '',
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,

--- a/robotframework_reportportal/result_visitor.py
+++ b/robotframework_reportportal/result_visitor.py
@@ -27,7 +27,7 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            'totaltests': suite.statistics.all.total if hasattr(suite.statistics, 'all') else suite.statistics.total,
+            'totaltests': getattr(suite.statistics, 'all', suite.statistics).total,
             'starttime': suite.starttime
         }
         listener.start_suite(suite.name, attrs)
@@ -41,7 +41,7 @@ class RobotResultsVisitor(ResultVisitor):
             'source': suite.source,
             'suites': suite.suites,
             'tests': suite.tests,
-            'totaltests': suite.statistics.all.total if hasattr(suite.statistics, 'all') else suite.statistics.total,
+            'totaltests': getattr(suite.statistics, 'all', suite.statistics).total,
             'starttime': suite.starttime,
             'endtime': suite.endtime,
             'elapsedtime': suite.elapsedtime,
@@ -58,7 +58,7 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            'critical': test.critical if hasattr(test, 'critical') else '',
+            'critical': getattr(test, 'critical', ''),
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,
@@ -72,7 +72,7 @@ class RobotResultsVisitor(ResultVisitor):
             # 'originalname': test.originalname,
             'doc': test.doc,
             'tags': list(test.tags),
-            'critical': test.critical if hasattr(test, 'critical') else '',
+            'critical': getattr(test, 'critical', ''),
             'template': '',
             # 'lineno': test.lineno,
             'starttime': test.starttime,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '5.0.4'
+__version__ = '5.0.5'
 
 requirements = [
     "reportportal-client>=5.0.5",


### PR DESCRIPTION
* Robotframework removed `Critical` functionality in new release v4.0 (Reference: https://github.com/robotframework/robotframework/issues/3624)
* `.all` is removed from `suite statisitics` when above critical change are done
* This pull request consist changes to support new and old versions of robotframework