### PR TITLE
fixes kw assigning false marking test as failed

### DIFF
--- a/robotframework_reportportal/result_visitor.py
+++ b/robotframework_reportportal/result_visitor.py
@@ -107,7 +107,7 @@ class RobotResultsVisitor(ResultVisitor):
             'starttime': kw.starttime,
             'endtime': kw.endtime,
             'elapsedtime': kw.elapsedtime,
-            'status': kw.status,
+            'status': 'PASS' if kw.assign else kw.status,
         }
         listener.end_keyword(kw.name, attrs)
 


### PR DESCRIPTION
Keywords like `Run Keyword And Return Status` is marking the test as FAILED when returning status==false.
This fix will make such assignments to always have status PASSED, regardless the status value.