### PR TITLE
Fix timestamp conversion and improve error message debugging

### DIFF
--- a/robotframework_reportportal/helpers.py
+++ b/robotframework_reportportal/helpers.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 if sys.version_info >= (3, 9):
     from zoneinfo import available_timezones, ZoneInfo
 from collections.abc import Iterable
-from typing import Optional
+from typing import Optional, Union
 
 
 def translate_glob_to_regex(pattern: Optional[str]) -> Optional[re.Pattern]:
@@ -121,7 +121,7 @@ else:
 LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
 
 
-def to_timestamp(time_str, tz_offset: Optional[str]) -> Optional[datetime]:
+def to_timestamp(time_str: Union[str, datetime, None], tz_offset: Optional[str]) -> Optional[datetime]:
     """Convert time string or datetime to timestamp with given timezone offset."""
     if not time_str:
         return None

--- a/robotframework_reportportal/helpers.py
+++ b/robotframework_reportportal/helpers.py
@@ -121,20 +121,24 @@ else:
 LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
 
 
-def to_timestamp(time_str: Optional[str], tz_offset: Optional[str]) -> Optional[datetime]:
-    """Convert time string to timestamp with given timezone offset."""
+def to_timestamp(time_str, tz_offset: Optional[str]) -> Optional[datetime]:
+    """Convert time string or datetime to timestamp with given timezone offset."""
     if not time_str:
         return None
 
-    dt = datetime.strptime(time_str, "%Y%m%d %H:%M:%S.%f")
-    if tz_offset:
-        if tz_offset in AVAILABLE_TIMEZONES:
-            tz = ZoneInfo(tz_offset)
-            dt = dt.replace(tzinfo=tz)
-        else:
-            hours, minutes = map(int, tz_offset.split(":"))
-            offset = timedelta(hours=hours, minutes=minutes)
-            dt = dt.replace(tzinfo=timezone(offset))
+    if isinstance(time_str, datetime):
+        dt = time_str
     else:
-        dt = dt.replace(tzinfo=LOCAL_TIMEZONE)  # make zone-aware
+        dt = datetime.strptime(time_str, "%Y%m%d %H:%M:%S.%f")
+    if dt.tzinfo is None:
+        if tz_offset:
+            if tz_offset in AVAILABLE_TIMEZONES:
+                tz = ZoneInfo(tz_offset)
+                dt = dt.replace(tzinfo=tz)
+            else:
+                hours, minutes = map(int, tz_offset.split(":"))
+                offset = timedelta(hours=hours, minutes=minutes)
+                dt = dt.replace(tzinfo=timezone(offset))
+        else:
+            dt = dt.replace(tzinfo=LOCAL_TIMEZONE)  # make zone-aware
     return dt.astimezone(tz=timezone.utc)  # unify Timezones to ease debugging

--- a/robotframework_reportportal/post_report.py
+++ b/robotframework_reportportal/post_report.py
@@ -93,8 +93,9 @@ def main():
 
     try:
         process(*values)
-    except TypeError:
-        print(__doc__)
+    except TypeError as e:
+        print(f"TypeError: {e}")
+        print("INFO: Visit the help (--help) for further details about available CLI arguments!")
         sys.exit(1)
     sys.exit(0)
 


### PR DESCRIPTION
This pull request introduces improvements to error handling and increases the flexibility of date/time parsing in the codebase. The most important changes are:

**Error Handling Improvements:**

* Updated the exception handling in `main()` within `post_report.py` to print the actual `TypeError` message and provide a helpful hint to use the help option for CLI arguments.

**Date/Time Parsing Enhancements:**

* Modified the `to_timestamp` function in `helpers.py` to accept both string and `datetime` objects for the `time_str` argument, improving its flexibility. The function now also checks if the provided datetime object has timezone information before applying the timezone offset.
* This fixed the following error message which i got with the latest version 5.7.X: `Exception: strptime() argument 1 must be str, not datetime.datetime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamp handling improved: accepts both datetime and formatted strings, preserves existing timezone info, and only assigns offsets when datetimes are timezone-naive.
  * CLI error messages clarified: parsing/argument errors now show the specific error and a hint to use --help for guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->